### PR TITLE
UI refinements

### DIFF
--- a/auth_and_profile_pages.dart
+++ b/auth_and_profile_pages.dart
@@ -173,11 +173,11 @@ class _AuthPageState extends State<_AuthPage> with TickerProviderStateMixin {
                       
                       // AhamAI Logo - smaller
                       Text(
-                        'AhamAI', 
-                        style: GoogleFonts.montserrat(
-                          fontSize: 36, 
+                        'AhamAI',
+                        style: GoogleFonts.spaceMono(
+                          fontSize: 36,
                           color: const Color(0xFF000000),
-                          fontWeight: FontWeight.w700,
+                          fontWeight: FontWeight.bold,
                         ),
                       ),
                       

--- a/character_chat_page.dart
+++ b/character_chat_page.dart
@@ -568,14 +568,6 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
                             ],
                           ),
                         ),
-                        if (isUser) ...[
-                          const SizedBox(width: 12),
-                          CircleAvatar(
-                            radius: 16,
-                            backgroundColor: const Color(0xFFEAE9E5),
-                            child: const Icon(Icons.person, size: 20, color: Color(0xFF000000)),
-                          ),
-                        ],
                       ],
                     ),
                   ),
@@ -618,7 +610,7 @@ class _CharacterChatPageState extends State<CharacterChatPage> {
             child: Container(
               decoration: BoxDecoration(
                 color: Colors.white,
-                borderRadius: BorderRadius.circular(24),
+                borderRadius: BorderRadius.circular(30),
                 border: Border.all(color: const Color(0xFFE0E0E0)),
                 boxShadow: [
                   BoxShadow(

--- a/character_editor.dart
+++ b/character_editor.dart
@@ -22,23 +22,6 @@ class _CharacterEditorState extends State<CharacterEditor> {
   
   final CharacterService _characterService = CharacterService();
   bool _isLoading = false;
-  Color? _selectedBackgroundColor;
-
-  // Predefined background colors for quick selection
-  final List<Color> _backgroundColorOptions = [
-    const Color(0xFFE3F2FD), // Light Blue
-    const Color(0xFFF3E5F5), // Light Purple
-    const Color(0xFFE8F5E8), // Light Green
-    const Color(0xFFFFF3E0), // Light Orange
-    const Color(0xFFFCE4EC), // Light Pink
-    const Color(0xFFE0F2F1), // Light Teal
-    const Color(0xFFF1F8E9), // Light Lime
-    const Color(0xFFFFF8E1), // Light Amber
-    const Color(0xFFEDE7F6), // Light Deep Purple
-    const Color(0xFFE8EAF6), // Light Indigo
-    const Color(0xFFE1F5FE), // Light Light Blue
-    const Color(0xFFE0F7FA), // Light Cyan
-  ];
 
   // Predefined avatar URLs for quick selection
   final List<String> _avatarOptions = [
@@ -84,9 +67,8 @@ class _CharacterEditorState extends State<CharacterEditor> {
     if (widget.character != null) {
       _loadCharacterData();
     } else {
-      // Set default avatar and background color for new characters
+      // Set default avatar for new characters
       _avatarUrlController.text = _avatarOptions.first;
-      _selectedBackgroundColor = _backgroundColorOptions.first;
     }
   }
 
@@ -97,9 +79,6 @@ class _CharacterEditorState extends State<CharacterEditor> {
     _systemPromptController.text = character.systemPrompt;
     _avatarUrlController.text = character.avatarUrl;
     _customTagController.text = character.customTag ?? '';
-    _selectedBackgroundColor = character.backgroundColor != null 
-        ? Color(character.backgroundColor!) 
-        : _backgroundColorOptions.first;
   }
 
   @override
@@ -215,7 +194,7 @@ class _CharacterEditorState extends State<CharacterEditor> {
         customTag: _customTagController.text.trim().isEmpty 
           ? null 
           : _customTagController.text.trim(),
-        backgroundColor: _selectedBackgroundColor?.value,
+        backgroundColor: null,
       );
 
       if (widget.character != null) {
@@ -386,12 +365,6 @@ class _CharacterEditorState extends State<CharacterEditor> {
               
               const SizedBox(height: 24),
               
-              // Background Color Section
-              _buildSectionTitle('Background Color'),
-              const SizedBox(height: 8),
-              _buildColorSelector(),
-              
-              const SizedBox(height: 24),
               
               // System Prompt Field
               Row(
@@ -489,7 +462,7 @@ class _CharacterEditorState extends State<CharacterEditor> {
     return Text(
       title,
       style: GoogleFonts.poppins(
-        fontSize: 16,
+        fontSize: 14,
         fontWeight: FontWeight.w600,
         color: Colors.black87,
       ),
@@ -522,62 +495,6 @@ class _CharacterEditorState extends State<CharacterEditor> {
     );
   }
 
-  Widget _buildColorSelector() {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.grey.shade300),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Choose a background color for your character',
-            style: GoogleFonts.poppins(
-              fontSize: 14,
-              color: Colors.grey.shade600,
-            ),
-          ),
-          const SizedBox(height: 12),
-          Wrap(
-            spacing: 12,
-            runSpacing: 12,
-            children: _backgroundColorOptions.map((color) {
-              final isSelected = _selectedBackgroundColor?.value == color.value;
-              return GestureDetector(
-                onTap: () {
-                  setState(() {
-                    _selectedBackgroundColor = color;
-                  });
-                },
-                child: Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: color,
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(
-                      color: isSelected ? Colors.black87 : Colors.grey.shade300,
-                      width: isSelected ? 3 : 1,
-                    ),
-                  ),
-                  child: isSelected
-                      ? const Icon(
-                          Icons.check,
-                          color: Colors.black87,
-                          size: 20,
-                        )
-                      : null,
-                ),
-              );
-            }).toList(),
-          ),
-        ],
-      ),
-    );
-  }
 
   void _showAvatarSelection() {
     showModalBottomSheet(

--- a/characters_page.dart
+++ b/characters_page.dart
@@ -160,7 +160,7 @@ class _CharactersPageState extends State<CharactersPage> with TickerProviderStat
               child: Container(
                 decoration: BoxDecoration(
                   color: Colors.white,
-                  borderRadius: BorderRadius.circular(20),
+                  borderRadius: BorderRadius.circular(30),
                   border: Border.all(color: const Color(0xFFE0E0E0)),
                   boxShadow: [
                     BoxShadow(
@@ -223,9 +223,9 @@ class _CharactersPageState extends State<CharactersPage> with TickerProviderStat
                       padding: const EdgeInsets.all(16),
                       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                         crossAxisCount: 2,
-                        crossAxisSpacing: 12,
-                        mainAxisSpacing: 12,
-                        childAspectRatio: 0.8,
+                        crossAxisSpacing: 16,
+                        mainAxisSpacing: 16,
+                        childAspectRatio: 0.75,
                       ),
                       itemCount: characters.length,
                       itemBuilder: (context, index) {
@@ -247,30 +247,30 @@ class _CharactersPageState extends State<CharactersPage> with TickerProviderStat
       child: Container(
         decoration: BoxDecoration(
           color: const Color(0xFFEAE9E5),
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: BorderRadius.circular(12),
           border: Border.all(color: const Color(0xFFC4C4C4).withOpacity(0.3)),
           boxShadow: [
             BoxShadow(
               color: Colors.black.withOpacity(0.05),
-              blurRadius: 8,
+              blurRadius: 6,
               offset: const Offset(0, 2),
             ),
           ],
         ),
         child: Padding(
-          padding: const EdgeInsets.all(12),
+          padding: const EdgeInsets.all(10),
           child: Column(
             children: [
               // Avatar
               Container(
-                width: 50,
-                height: 50,
+                width: 40,
+                height: 40,
                 decoration: BoxDecoration(
                   color: const Color(0xFF000000),
-                  borderRadius: BorderRadius.circular(25),
+                  borderRadius: BorderRadius.circular(20),
                 ),
                 child: ClipRRect(
-                  borderRadius: BorderRadius.circular(25),
+                  borderRadius: BorderRadius.circular(20),
                   child: character.avatarUrl.isNotEmpty
                       ? Image.network(
                           character.avatarUrl,

--- a/chat_page.dart
+++ b/chat_page.dart
@@ -580,14 +580,6 @@ class ChatPageState extends State<ChatPage> {
         });
         
         _scrollToBottom();
-        
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Image uploaded successfully'),
-            backgroundColor: Colors.green,
-            duration: Duration(seconds: 2),
-          ),
-        );
       }
     } catch (e) {
       print('Error picking image: $e');

--- a/main_shell.dart
+++ b/main_shell.dart
@@ -647,33 +647,36 @@ class _MainShellState extends State<MainShell> with TickerProviderStateMixin {
       appBar: AppBar(
         title: GestureDetector(
           onTap: _showModelSelectionSheet,
-          child: Row(
+          child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                'AhamAI',
-                style: GoogleFonts.montserrat(
-                  fontSize: 18,
-                  fontWeight: FontWeight.w700,
-                  color: const Color(0xFF000000),
-                ),
-              ),
-              if (_isTemporaryChatMode) ...[
-                const SizedBox(width: 6),
-                Container(
-                  width: 6,
-                  height: 6,
-                  decoration: const BoxDecoration(
-                    color: Color(0xFF000000),
-                    shape: BoxShape.circle,
+              if (_isTemporaryChatMode)
+                Text(
+                  'private',
+                  style: GoogleFonts.inter(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w500,
+                    color: const Color(0xFF000000),
                   ),
                 ),
-              ],
-              const SizedBox(width: 8),
-              const Icon(
-                Icons.keyboard_arrow_down_rounded,
-                color: Color(0xFFA3A3A3),
-                size: 20,
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'AhamAI',
+                    style: GoogleFonts.spaceMono(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: const Color(0xFF000000),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  const Icon(
+                    Icons.keyboard_arrow_down_rounded,
+                    color: Color(0xFFA3A3A3),
+                    size: 20,
+                  ),
+                ],
               ),
             ],
           ),
@@ -711,12 +714,8 @@ class _MainShellState extends State<MainShell> with TickerProviderStateMixin {
                 width: 42,
                 height: 42,
                 decoration: BoxDecoration(
-                  color: Colors.transparent, // Remove background
+                  color: Colors.transparent,
                   borderRadius: BorderRadius.circular(21),
-                  border: _isTemporaryChatMode ? Border.all(
-                    color: const Color(0xFF000000),
-                    width: 2,
-                  ) : null,
                 ),
                 child: Material(
                   color: Colors.transparent,


### PR DESCRIPTION
## Summary
- switch app logo to Space Mono
- show small `private` label in temporary chat mode
- refine characters UI search bar and cards
- round character chat input
- remove user avatar and success snackbar
- streamline character editor layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883b42aec40832ea111707a5001e658